### PR TITLE
Gradle Cleanup, Gradle Organisation, Information Added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,23 +40,39 @@ dependencies {
     modImplementation "maven.modrinth:spell-power:${project.spellpower_version}-fabric"
     modImplementation("maven.modrinth:spell-engine:${project.spell_engine_version}-fabric")
 
-    implementation("com.github.LlamaLad7:MixinExtras:0.1.1")
-    annotationProcessor("com.github.LlamaLad7:MixinExtras:0.1.1")
+    implementation("com.github.LlamaLad7:MixinExtras:${mixin_extras_version}")
+    annotationProcessor("com.github.LlamaLad7:MixinExtras:${mixin_extras_version}")
 
     modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
         exclude(group: "net.fabricmc.fabric-api")
     }
 
-    }
+}
 
 processResources {
+    inputs.property "mod_id", project.mod_id
+    inputs.property "mod_name", project.mod_name
+    inputs.property "license", project.license
     inputs.property "version", project.version
+    inputs.property "mod_authors", project.mod_authors
+    inputs.property "mod_description", project.mod_description
+    inputs.property "contact_homepage", project.contact_homepage
+    inputs.property "contact_sources", project.contact_sources
+    inputs.property "contact_issues", project.contact_issues
     inputs.property "minecraft_version", project.minecraft_version
     inputs.property "loader_version", project.loader_version
     filteringCharset "UTF-8"
 
     filesMatching("fabric.mod.json") {
-        expand "version": project.version,
+        expand "mod_id": project.mod_id,
+                "mod_name": project.version,
+                "license": project.license,
+                "version": project.version,
+                "mod_authors": project.mod_authors,
+                "mod_description": project.mod_description,
+                "contact_homepage": project.contact_homepage,
+                "contact_sources": project.contact_sources,
+                "contact_issues": project.contact_issues,
                 "minecraft_version": project.minecraft_version,
                 "loader_version": project.loader_version
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,15 +6,24 @@ org.gradle.jvmargs=-Xmx4G
 	minecraft_version=1.19.2
 	yarn_mappings=1.19.2+build.28
 	loader_version=0.14.21
+	fabric_version=0.76.0+1.19.2
 
 # Mod Properties
-	mod_version = 0.04
+	mod_id = simplyskills
+	mod_name = Simply Skills
+	license = Timefall Development License 1.1
+	mod_version = 0.4.0-beta
 	maven_group = net.sweenus
 	archives_base_name = simplyskills
+	mod_authors = Sweenus", "Timefall Development
+	mod_description = A comprehensive skill tree mod with a focus on combat specialisations. THIS IS A BETA - THERE WILL BE BUGS
+	contact_homepage = https://www.curseforge.com/minecraft/mc-mods/simply_skills
+	contact_sources = https://github.com/Sweenus/SimplySkills
+	contact_issues = https://github.com/Sweenus/SimplySkills/issues
 
 # Dependencies
-	# check this on https://modmuss50.me/fabric.html
-	fabric_version=0.76.0+1.19.2
-	spellpower_version=0.9.12+1.19
-	spell_engine_version=0.9.24+1.19
 	cloth_config_version=8.2.88
+	mixin_extras_version=0.1.1
+	puffish_skills_version=4568619
+	spell_engine_version=0.9.24+1.19
+  	spellpower_version=0.9.12+1.19

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,14 +1,16 @@
 {
   "schemaVersion": 1,
-  "id": "simplyskills",
-  "version": "BETA ${version}",
-  "name": "Simply Skills",
-  "description": "A comprehensive skill tree mod with a focus on combat specialisations. \n\nTHIS IS A BETA - THERE WILL BE BUGS",
-  "authors": [],
+  "id": "${mod_id}",
+  "version": "${version}",
+  "name": "${mod_name}",
+  "description": "${mod_description}",
+  "authors": ["${mod_authors}"],
   "contact": {
-    "repo": "https://github.com/Sweenus/SimplySkills"
+    "homepage": "${contact_homepage}",
+    "sources": "${contact_sources}",
+    "issues": "${contact_issues}"
   },
-  "license": "Timefall Development License",
+  "license": "${license}",
   "icon": "assets/simplyskills/icon.png",
   "environment": "*",
   "entrypoints": {


### PR DESCRIPTION
 - Reorganised `gradle.properties` file to allow for easy updating of end user facing content as well as development content
 - Updated `fabric.mod.json` to make use added of `gradle.properties` properties (?, terms can be weird)
 - Changed versioning of Simply Skills to be SemVer compliant
 - Updated Licence to proper version reference in `fabric.mod.json` file to be Timefall Development License 1.1
 - Added authorship and contact information